### PR TITLE
Pass ignore flag to glob to find ignored files

### DIFF
--- a/autoload/autocd.vim
+++ b/autoload/autocd.vim
@@ -87,8 +87,8 @@ fun! s:search_marker_set(dir, markers)
   while l:dir !~# '^.$' && l:depthCounter != 0
 
     for marker in a:markers
-      if(!empty(glob(l:dir . '/' . marker)))
-        return l:dir    
+      if(!empty(glob(l:dir . '/' . marker, 1)))
+        return l:dir
       endif
     endfor
 


### PR DESCRIPTION
Fixes #1

Prior to this, if you had e.g. `.git` in your `wildignore` variable
(which is useful to avoid browsing it by default), calling `glob()`
would not be able to find .git directories, meaning you can't use .git
to detect projects.